### PR TITLE
Add `-q` flag to control()

### DIFF
--- a/rofi-mpd
+++ b/rofi-mpd
@@ -268,9 +268,9 @@ shuffle() {
 control() {
 	
 	CHOICE=$(echo -e "Toggle Play\nNext\nPrevious\n"| $ROFI);
-	if [ "$CHOICE" = "Toggle Play" ]; then $($MPC toggle); fi
-	if [ "$CHOICE" = "Next" ]; 	  then $($MPC next); fi
-	if [ "$CHOICE" = "Previous" ]; 	  then $($MPC prev); fi
+	if [ "$CHOICE" = "Toggle Play" ]; then $($MPC -q toggle); fi
+	if [ "$CHOICE" = "Next" ]; 	  then $($MPC -q next); fi
+	if [ "$CHOICE" = "Previous" ]; 	  then $($MPC -q prev); fi
 
 }
 


### PR DESCRIPTION
This fixes the following error:

```
kartik@ksvoid % ./rofi-mpd -c 
./rofi-mpd: line 271: Pink: command not found
```

Thank you for all the enhancements to the original script btw. Very useful. :)